### PR TITLE
Don't reload when exiting game

### DIFF
--- a/client/assets/icons.js
+++ b/client/assets/icons.js
@@ -24,3 +24,8 @@ icons.both = `
 		<circle cx="147.5" cy="147.5" r="34.5" stroke="var(--blue)" stroke-width="18"/>
 	</svg>
 `
+icons.heart = `
+	<svg fill="none" height="300" viewBox="0 0 300 300" width="300" xmlns="http://www.w3.org/2000/svg">
+		<path d="m141.295 121.107c-4.202 13.512-79.6576-100.2172-110.9516-15.202-31.29407 85.016 116.6416 158.208 120.6246 157.082s188.902-132.872 97.865-198.1819c-91.038-65.310002-103.336 42.7889-107.538 56.3019z" stroke="var(--red)" stroke-width="30"/>
+	</svg>
+`

--- a/client/client.js
+++ b/client/client.js
@@ -1,9 +1,10 @@
 import server from './events/outgoing.js';
 import status from './scripts/toast.js'
 import Cookie from './modules/js.cookie.mjs';
-import {game_id, statusBarSetGameInfo} from "./scripts/uttt.js";
+import {game_id, statusBarSetGameInfo, updateState} from "./scripts/uttt.js";
 import status_bar from "./scripts/status_bar.js";
 import Cookies from "./modules/js.cookie.mjs";
+import {icons} from "./assets/icons.js";
 
 const host = window.location.hostname;
 const port = window.location.port;
@@ -19,31 +20,34 @@ let interval;
 export let prepared = false;
 
 export let connection_id = Cookie.get('connection_id');
+
 export function setConnectionID(new_connection_id) {
 	connection_id = new_connection_id;
 }
 
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function () {
 	adjustTitleText();
-
 	statusBarSetMyLinks();
+	resetPieceMarker();
 
 	connect();
 	interval = setInterval(tryConnect, 1000);
 });
 
-// Websocket
+window.addEventListener('popstate', function () {
+	let url = new URL(window.location);
+	const url_params = new URLSearchParams(url.search);
 
-window.addEventListener('popstate', function() {
-	const urlParams = new URLSearchParams(window.location.search);
-	const param_id = urlParams.get('room');
+	const param_id = url_params.get('room');
 
-	if (game_id && param_id) {
-		window.location.reload();
+	if (!param_id) {
+		updateState();
+	} else if (param_id !== game_id) {
+		server.join(param_id, true);
 	}
-	if (!param_id) return;
-	if (game_id && param_id !== game_id ) server.join(param_id);
 });
+
+// Websocket
 
 function connect() {
 	if (location.protocol === 'https:') ws = new WebSocket(`wss://${host}:${port}`);
@@ -93,8 +97,8 @@ function connect() {
 	};
 }
 
-function tryConnect(){
-	if(!ws || ws.readyState === WebSocket.CLOSED) {
+function tryConnect() {
+	if (!ws || ws.readyState === WebSocket.CLOSED) {
 		console.log(attempts);
 		if (attempts > 10) {
 			clearInterval(interval);
@@ -114,11 +118,13 @@ function tryConnect(){
 
 // Elements
 
+export const how_to_play = document.getElementById('how-to-play');
 const title_text = document.getElementById('title-text');
 const join_code_input = document.getElementById('join-code');
 const join_button = document.getElementById('join');
 const start_button = document.getElementById('start');
 const leave_button = document.getElementById("leave");
+const piece_marker = document.getElementById("piece-marker");
 
 // Resize Observers
 
@@ -126,12 +132,13 @@ const titleTextResizeObserver = new ResizeObserver(adjustTitleText);
 titleTextResizeObserver.observe(title_text);
 
 export function adjustTitleText() {
-	const titleText = document.getElementById('title-text');
+	const title_text = document.getElementById('title-text');
 
-	if (titleText.offsetWidth < 220) titleText.textContent = 'UTTT';
-	else if (titleText.offsetWidth < 360) titleText.textContent = 'Ultimate TTT';
-	else titleText.textContent = 'Ultimate Tic-Tac-Toe';
+	if (title_text.offsetWidth < 220) title_text.textContent = 'UTTT';
+	else if (title_text.offsetWidth < 360) title_text.textContent = 'Ultimate TTT';
+	else title_text.textContent = 'Ultimate Tic-Tac-Toe';
 }
+
 const startButtonResizeObserver = new ResizeObserver(adjustStartButton);
 startButtonResizeObserver.observe(start_button);
 
@@ -167,7 +174,7 @@ start_button.addEventListener("click", () => {
 });
 
 leave_button.addEventListener("click", () => {
-	window.location.href = '/';
+	updateState();
 });
 
 export function resetStartButton() {
@@ -176,14 +183,16 @@ export function resetStartButton() {
 }
 
 export function addLeaveButton() {
-	const leaveButton = document.getElementById('leave');
-	if (leaveButton) leaveButton.classList.remove('hidden')
-
-	const startButton = document.getElementById('start');
-	if (startButton) startButton.classList.remove('right')
+	if (leave_button) leave_button.classList.remove('hidden')
+	if (start_button) start_button.classList.remove('right')
 }
 
-function statusBarSetMyLinks() {
+export function removeLeaveButton() {
+	if (leave_button) leave_button.classList.add('hidden')
+	if (start_button) start_button.classList.add('right')
+}
+
+export function statusBarSetMyLinks() {
 	status_bar.reset();
 	status_bar.addBlock('', 'my site', `<a href="https://ibll.dev/">ibll.dev</a>`)
 	status_bar.addBlock('', 'made by', `Isbell!`)
@@ -196,4 +205,8 @@ function statusBarSetChooseSize() {
 	status_bar.addBlock('', 'ultimate', '2 layers', server.start, 2);
 	status_bar.addBlock('', 'nightmare', '3 layers', server.start, 3);
 	status_bar.addBlock('', 'endless', 'good luck', server.start, 0);
+}
+
+export function resetPieceMarker() {
+	piece_marker.innerHTML = icons.heart;
 }

--- a/client/index.html
+++ b/client/index.html
@@ -25,11 +25,7 @@
 <div class="panel" id="primary-panel">
 	<div id="top-bar" class="bar">
 		<div id="title-box">
-			<div id='piece-marker'>
-				<svg fill="none" height="300" viewBox="0 0 300 300" width="300" xmlns="http://www.w3.org/2000/svg">
-					<path d="m141.295 121.107c-4.202 13.512-79.6576-100.2172-110.9516-15.202-31.29407 85.016 116.6416 158.208 120.6246 157.082s188.902-132.872 97.865-198.1819c-91.038-65.310002-103.336 42.7889-107.538 56.3019z" stroke="var(--red)" stroke-width="30"/>
-				</svg>
-			</div>
+			<div id='piece-marker'></div>
 			<h1 id='title-text'>Ultimate Tic-Tac-Toe</h1>
 		</div>
 		<div class="button-panel">

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import http from 'http';
-import loadStatic  from "./server/load_static.js";
+import loadStatic from "./server/load_static.js";
 import {createWSS} from "./server/wss.js";
 
 export const domain = `uttt.ibll.dev`;

--- a/package.json
+++ b/package.json
@@ -1,20 +1,19 @@
 {
-  "name": "uttt",
-  "version": "1.0.0",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
-  },
-  "type": "module",
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
-  "dependencies": {
-    "js-cookie": "^3.0.5",
-    "mime": "^4.0.4",
-    "uuid": "^10.0.0",
-    "ws": "^8.18.0"
-  }
+	"name": "uttt",
+	"version": "1.0.0",
+	"main": "index.js",
+	"scripts": {
+		"start": "node index.js"
+	},
+	"type": "module",
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"description": "",
+	"dependencies": {
+		"js-cookie": "^3.0.5",
+		"mime": "^4.0.4",
+		"uuid": "^10.0.0",
+		"ws": "^8.18.0"
+	}
 }

--- a/server/events/incoming/join.js
+++ b/server/events/incoming/join.js
@@ -1,4 +1,4 @@
-import { join } from '../../uttt.js'
+import {join} from '../../uttt.js'
 
 export default async (ws, payload) => {
 	console.log(`${ws.connection_id} requesting to join game ${payload.game_id}`);

--- a/server/events/incoming/place.js
+++ b/server/events/incoming/place.js
@@ -1,4 +1,4 @@
-import { games } from '../../uttt.js';
+import {games} from '../../uttt.js';
 
 export default async (ws, payload) => {
 	const game_id = payload.game_id;

--- a/server/events/incoming/start.js
+++ b/server/events/incoming/start.js
@@ -1,4 +1,4 @@
-import { createGame, join } from '../../uttt.js';
+import {createGame, join} from '../../uttt.js';
 
 export default async (ws, payload) => {
 	const size = parseInt(payload.size);

--- a/server/events/outgoing.js
+++ b/server/events/outgoing.js
@@ -4,29 +4,34 @@ function sendToClient(ws, message) {
 	ws.send(JSON.stringify(message));
 }
 
-client_API.display = function(ws, content) {
+client_API.display = function (ws, content) {
 	sendToClient(ws, {type: "display", content});
 }
 
-client_API.prepareClient = function(ws, client_events, client_events_path, connection_id) {
+client_API.prepareClient = function (ws, client_events, client_events_path, connection_id) {
 	sendToClient(ws, {type: "prepare_client", client_events, client_events_path, connection_id});
 }
 
-client_API.updateState = function(ws, game_id, board_depth, board_state, active_grids, client_piece, next_player_id, moves, start_time, end_time, endless) {
-	sendToClient(ws, {type: "update_state", game_id, board_depth, board_state, active_grids, client_piece, next_player_id, moves, start_time, end_time, endless});
+client_API.updateState = function (ws, game_id, board_depth, board_state, active_grids, client_piece, next_player_id, moves, start_time, end_time, endless) {
+	sendToClient(ws, {
+		type: "update_state",
+		game_id,
+		board_depth,
+		board_state,
+		active_grids,
+		client_piece,
+		next_player_id,
+		moves,
+		start_time,
+		end_time,
+		endless
+	});
 }
 
-client_API.registerPiece = function(ws, piece) {
+client_API.registerPiece = function (ws, piece) {
 	sendToClient(ws, {type: "register_piece", piece});
 }
 
-/**
- * @param ws {WebSocket} Connection to send message to
- * @param pieces {Array} Array of pieces
- * @param active_grids {Object} Active grids
- * @param next_piece {string} Next player piece id
- * @param moves {number} Number of moves in game
- */
 client_API.pieceUpdate = function (ws, pieces, active_grids, next_piece, moves) {
 	sendToClient(ws, {type: "piece_update", pieces, active_grids, next_piece, moves});
 };

--- a/server/load_static.js
+++ b/server/load_static.js
@@ -2,8 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import mime from 'mime';
 import url from 'url';
-import { domain } from '../index.js';
-import { games } from './uttt.js';
+import {domain} from '../index.js';
+import {games} from './uttt.js';
 
 const __dirname = import.meta.dirname;
 const client_dir = path.resolve(__dirname, '../client');
@@ -18,14 +18,14 @@ export default function loadStatic(req, res) {
 			const errorPage = err.code === 'ENOENT' ? '404.html' : '500.html';
 			const statusCode = err.code === 'ENOENT' ? 404 : 500;
 			fs.readFile(path.join(client_dir, errorPage), (error, errorContent) => {
-				res.writeHead(statusCode, { 'Content-Type': 'text/html' });
+				res.writeHead(statusCode, {'Content-Type': 'text/html'});
 				res.end(errorContent || `Server Error: ${err.code}`, 'utf-8');
 			});
 
 			return;
 		}
 
-		const headers = { 'Content-Type': contentType };
+		const headers = {'Content-Type': contentType};
 
 		const cache_types = ['image/', 'video/', 'audio/', 'font/'];
 

--- a/server/uttt.js
+++ b/server/uttt.js
@@ -133,7 +133,7 @@ export class Game {
 		if (cell_layer === 0) this.moves++;
 
 		const piece = connection_id ? this.active_player : null;
-		this.queued_pieces.push({ cell_layer, cell_number, piece });
+		this.queued_pieces.push({cell_layer, cell_number, piece});
 
 		// Win the grid if necessary
 		let already_set_active = false;
@@ -198,7 +198,7 @@ export class Game {
 	findNextActiveGrid(grid_layer, grid_number, pos_in_grid, previous_cells) {
 		const cell_layer = grid_layer - 1;
 		const cell_number = grid_number * 9;
-		const next_number = cell_number  + pos_in_grid;
+		const next_number = cell_number + pos_in_grid;
 
 		this.active_grids = {};
 		if (!this.active_grids[cell_layer]) this.active_grids[cell_layer] = {};
@@ -244,7 +244,7 @@ export class Game {
 	checkWhoWonGrid(grid_layer, grid_number) {
 		const cell_layer = grid_layer - 1;
 		const first_cell_number = grid_number * 9;
-		const cells = Array.from({ length: 9 }, (_, i) => this.board_state[cell_layer]?.[first_cell_number + i]);
+		const cells = Array.from({length: 9}, (_, i) => this.board_state[cell_layer]?.[first_cell_number + i]);
 
 		const lines = [
 			[cells[0], cells[1], cells[2]], // rows
@@ -276,7 +276,7 @@ export class Game {
 		const new_board_depth = this.board_depth + 1;
 		const new_board_state = {};
 		const new_active_grids = {};
-		new_active_grids[new_board_depth] = { 0: true };
+		new_active_grids[new_board_depth] = {0: true};
 
 		let sub_cell_shift = this.last_cell;
 		while (sub_cell_shift >= 9) {

--- a/server/uttt.js
+++ b/server/uttt.js
@@ -30,7 +30,7 @@ function createGameID(length) {
 }
 
 export function join(ws, game_id, automatic) {
-	game_id = game_id.trim().toLowerCase();
+	game_id = game_id?.trim().toLowerCase();
 	const game = games[game_id];
 
 	// Reset client if it's automatically on a game that no longer exists

--- a/server/wss.js
+++ b/server/wss.js
@@ -13,7 +13,7 @@ const ABSOLUTE_CLIENT_EVENTS_DIR = path.join(__dirname, '../client/', CLIENT_EVE
 const CLIENT_EVENTS = fetchEventsIn(ABSOLUTE_CLIENT_EVENTS_DIR);
 
 export function createWSS(server) {
-	const wss = new WebSocketServer({ server });
+	const wss = new WebSocketServer({server});
 	wss.on('connection', wssConnection);
 	return wss;
 }
@@ -42,7 +42,7 @@ async function wssConnection(ws, response) {
 			let payload = JSON.parse(data)
 			if (!payload.type) return;
 
-			const filePath = path.join(__dirname, SERVER_EVENTS_DIR,  payload.type + '.js');
+			const filePath = path.join(__dirname, SERVER_EVENTS_DIR, payload.type + '.js');
 			fs.readFile(filePath, (err) => {
 				if (!ws.connection_id) {
 					console.error(`Client does not have a connection id. ${payload}`);


### PR DESCRIPTION
Previous behaviour:

Certain features on the main/tutorial page were only generated on initial page laod, and deleted or modified with javascript later. This meant that the only way to go to a fresh start was to reload the page again.

This PR changes this behaviour. When leaving a game or getting booted by the server, the client now restores everything to default without a refresh. Navigation is more smooth as a result. Additionally, issues with the `popstate` event and `history.pushState` function were causing awkward behaviour when using the browser forward and backwards buttons. This is now fixed in almost every case — only remaining oddity I've noticed is going back to a game the server no longer recognises redirects the page to the homepage, immediately removing forward history. his is enough of an edge case I figure it doesn't matter.